### PR TITLE
feat: ScheduleServer, VoteServer에서 클라이언트의 호스트여부 판정 로직 추가

### DIFF
--- a/src/client/Client.java
+++ b/src/client/Client.java
@@ -1,9 +1,6 @@
 package client;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.PrintWriter;
+import java.io.*;
 import java.net.Socket;
 
 import static client.ClientOrderGenerator.*;
@@ -60,6 +57,9 @@ public class Client {
                             br = new BufferedReader(new InputStreamReader(sock.getInputStream()));
                             pw = new PrintWriter(sock.getOutputStream(), true);
 
+                            // ScheduleServer로 호스트 여부와 클라이언트의 이름을 전송
+                            // 반드시 순서가 지켜져야합니다!
+                            pw.println(isHost);
                             pw.println(name);
 
                             if (isHost) { // 호스트 클라이언트가 수행할 코드 영역 : 호스트 클라이언트는 시작일, 종료일을 설정해야함
@@ -122,6 +122,9 @@ public class Client {
                             br = new BufferedReader(new InputStreamReader(sock.getInputStream()));
                             pw = new PrintWriter(sock.getOutputStream(), true);
 
+                            // VoteServer로 호스트 여부와 클라이언트의 이름을 전송
+                            // 반드시 순서가 지켜져야합니다!
+                            pw.println(isHost);
                             pw.println(name);
 
 
@@ -130,7 +133,6 @@ public class Client {
                             }
 
                             if (!isHost) { // 일반 클라이언트가 수행할 코드 영역 : 일반 클라이언트는 오직 투표만 수행
-
                             }
 
 

--- a/src/server/handler/ChatHandler.java
+++ b/src/server/handler/ChatHandler.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.net.Socket;
+import java.util.Collection;
 import java.util.Map;
 
 public class ChatHandler extends Thread {
@@ -13,7 +14,7 @@ public class ChatHandler extends Thread {
     Map<String, PrintWriter> onChatClients;
 
 
-    public ChatHandler(Socket socket, Map<String, PrintWriter> onChatClients){
+    public ChatHandler(Socket socket, Map<String, PrintWriter> onChatClients) {
         this.socket = socket;
         this.onChatClients = onChatClients;
     }
@@ -23,7 +24,7 @@ public class ChatHandler extends Thread {
         PrintWriter pw = null;
         BufferedReader br = null;
 
-        try{
+        try {
             br = new BufferedReader(new InputStreamReader(socket.getInputStream()));
             pw = new PrintWriter(socket.getOutputStream(), true);
 
@@ -31,9 +32,30 @@ public class ChatHandler extends Thread {
 
             onChatClients.put(userName, pw);
 
-            System.out.println(userName + "님이 일정 조율 기능을 사용하셨습니다.");
+            System.out.println(userName + "님이 채팅 기능을 사용하셨습니다.");
         } catch (IOException e) {
             throw new RuntimeException(e);
+        } finally {
+            try {
+                if (br != null) br.close();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (pw != null) pw.close();
         }
     }
+
+
+    public void broadcast(String message) {
+
+        synchronized (onChatClients) {
+            Collection<PrintWriter> collection = onChatClients.values();
+            for (PrintWriter pw : collection) {
+                pw.println(message);
+                pw.flush();
+            }
+        }
+    }
+
 }

--- a/src/server/handler/PlaceSuggestHandler.java
+++ b/src/server/handler/PlaceSuggestHandler.java
@@ -7,13 +7,13 @@ import java.io.PrintWriter;
 import java.net.Socket;
 import java.util.Map;
 
-public class PlaceSuggestHandler extends Thread{
+public class PlaceSuggestHandler extends Thread {
 
     Socket socket;
     Map<String, PrintWriter> onPlaceSuggestClients;
 
 
-    public PlaceSuggestHandler(Socket socket, Map<String, PrintWriter> onPlaceSuggestClients){
+    public PlaceSuggestHandler(Socket socket, Map<String, PrintWriter> onPlaceSuggestClients) {
         this.socket = socket;
         this.onPlaceSuggestClients = onPlaceSuggestClients;
     }
@@ -23,7 +23,7 @@ public class PlaceSuggestHandler extends Thread{
         PrintWriter pw = null;
         BufferedReader br = null;
 
-        try{
+        try {
             br = new BufferedReader(new InputStreamReader(socket.getInputStream()));
             pw = new PrintWriter(socket.getOutputStream(), true);
 
@@ -31,9 +31,19 @@ public class PlaceSuggestHandler extends Thread{
 
             onPlaceSuggestClients.put(userName, pw);
 
-            System.out.println(userName + "님이 일정 조율 기능을 사용하셨습니다.");
+            System.out.println(userName + "님이 장소 제시 기능을 사용하셨습니다.");
         } catch (IOException e) {
             throw new RuntimeException(e);
+        } finally {
+
+            try {
+                if (br != null) br.close();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (pw != null) pw.close();
         }
+
     }
 }

--- a/src/server/handler/ScheduleHandler.java
+++ b/src/server/handler/ScheduleHandler.java
@@ -9,24 +9,21 @@ import java.util.Map;
 
 public class ScheduleHandler extends Thread {
 
-    Socket socket;
+    BufferedReader br;
+    PrintWriter pw;
     Map<String, PrintWriter> onScheduleClients;
 
 
-    public ScheduleHandler(Socket socket, Map<String, PrintWriter> onScheduleClients){
-        this.socket = socket;
+    public ScheduleHandler(BufferedReader br, PrintWriter pw, Map<String, PrintWriter> onScheduleClients){
+        this.br = br;
+        this.pw = pw;
         this.onScheduleClients = onScheduleClients;
     }
 
     @Override
     public void run() {
-        PrintWriter pw = null;
-        BufferedReader br = null;
 
         try{
-            br = new BufferedReader(new InputStreamReader(socket.getInputStream()));
-            pw = new PrintWriter(socket.getOutputStream(), true);
-
             String userName = br.readLine();
 
             onScheduleClients.put(userName, pw);
@@ -34,6 +31,14 @@ public class ScheduleHandler extends Thread {
             System.out.println(userName + "님이 날짜 조율 기능을 사용하셨습니다.");
         } catch (IOException e) {
             throw new RuntimeException(e);
+        } finally {
+            try {
+                if(br != null) br.close();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+
+            if(pw != null) pw.close();
         }
     }
 }

--- a/src/server/handler/StatisticHandler.java
+++ b/src/server/handler/StatisticHandler.java
@@ -31,9 +31,17 @@ public class StatisticHandler extends Thread {
 
             onStatisticClients.put(userName, pw);
 
-            System.out.println(userName + "님이 일정 조율 기능을 사용하셨습니다.");
+            System.out.println(userName + "님이 일정 확인 기능을 사용하셨습니다.");
         } catch (IOException e) {
             throw new RuntimeException(e);
+        } finally {
+            try {
+                if(br != null) br.close();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+
+            if(pw != null) pw.close();
         }
     }
 }

--- a/src/server/handler/VoteHandler.java
+++ b/src/server/handler/VoteHandler.java
@@ -5,35 +5,46 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.net.Socket;
+import java.nio.Buffer;
 import java.util.Map;
 
 public class VoteHandler extends Thread {
 
-    Socket socket;
+    BufferedReader br;
+    PrintWriter pw;
     Map<String, PrintWriter> onVoteClients;
 
 
-    public VoteHandler(Socket socket, Map<String, PrintWriter> onVoteClients){
-        this.socket = socket;
+    public VoteHandler(BufferedReader br, PrintWriter pw, Map<String, PrintWriter> onVoteClients) {
+        this.br = br;
+        this.pw = pw;
         this.onVoteClients = onVoteClients;
     }
 
     @Override
     public void run() {
-        PrintWriter pw = null;
-        BufferedReader br = null;
 
         try{
-            br = new BufferedReader(new InputStreamReader(socket.getInputStream()));
-            pw = new PrintWriter(socket.getOutputStream(), true);
-
             String userName = br.readLine();
 
             onVoteClients.put(userName, pw);
 
-            System.out.println(userName + "님이 일정 조율 기능을 사용하셨습니다.");
+            System.out.println(userName + "님이 투표 기능을 사용하셨습니다.");
+
         } catch (IOException e) {
             throw new RuntimeException(e);
+        } finally {
+
+            try {
+                if (br != null) br.close();
+
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (pw != null) pw.close();
         }
+
+
     }
 }

--- a/src/server/serverThread/ChatServer.java
+++ b/src/server/serverThread/ChatServer.java
@@ -19,7 +19,6 @@ public class ChatServer extends Thread {
         ServerSocket chatServerSocket = null;
 
         try{
-
             chatServerSocket = new ServerSocket(10005);
 
             while(true) {

--- a/src/server/serverThread/ScheduleServer.java
+++ b/src/server/serverThread/ScheduleServer.java
@@ -3,7 +3,9 @@ package server.serverThread;
 import server.handler.ChatHandler;
 import server.handler.ScheduleHandler;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.net.ServerSocket;
 import java.net.Socket;
@@ -26,7 +28,28 @@ public class ScheduleServer extends Thread{
                 Socket socket = scheduleServerSocket.accept();
                 System.out.println("날짜 조율 기능 연결");
 
-                ScheduleHandler scheduleHandler = new ScheduleHandler(socket, onScheduleClients);
+                BufferedReader br = new BufferedReader(new InputStreamReader(socket.getInputStream()));
+                PrintWriter pw = new PrintWriter(socket.getOutputStream(), true);
+
+                boolean isHost = Boolean.parseBoolean(br.readLine());
+
+                if(isHost) {
+                    String hostName = br.readLine();
+                    System.out.println("호스트 : " + hostName + "가 날짜 조율 기능에...?");
+                    continue;
+                }
+
+                /*
+                    VoteServer에서 스트림을 연 후에 호스트 여부를 확인하고, VoteHandler의 인자로 socket을 전달한 후,
+                    Vote Handler에서 socket으로부터 스트림을 열어 사용자의 이름을 읽어오려고 했습니다.
+                    근데 VoteHandler 내부에서 socket을 다시 열게 되니 스트림 안에 써준 내용들이 날라가서
+                    이름이 계속 null 값을 읽어오더라구요. 그래서 인자로 br, pw 를 직접 넘겨줬습니다.
+
+                    ScheduleHandler(socket, onVoteClients) -> X
+
+                    ScheduleHandler(br, pw, onVoteClients) -> O
+                */
+                ScheduleHandler scheduleHandler = new ScheduleHandler(br, pw, onScheduleClients);
                 scheduleHandler.start();
             }
         } catch (IOException e) {

--- a/src/server/serverThread/VoteServer.java
+++ b/src/server/serverThread/VoteServer.java
@@ -3,8 +3,7 @@ package server.serverThread;
 import server.handler.ChatHandler;
 import server.handler.VoteHandler;
 
-import java.io.IOException;
-import java.io.PrintWriter;
+import java.io.*;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.HashMap;
@@ -19,17 +18,40 @@ public class VoteServer extends Thread {
         System.out.println("투표 기능 연결 대기중");
         ServerSocket voteServerSocket = null;
 
-        try{
+        try {
             voteServerSocket = new ServerSocket(10003);
 
-            while(true) {
+            while (true) {
                 Socket socket = voteServerSocket.accept();
                 System.out.println("투표 기능 연결");
 
-                VoteHandler voteHandler = new VoteHandler(socket, onVoteClients);
+                BufferedReader br = new BufferedReader(new InputStreamReader(socket.getInputStream()));
+                PrintWriter pw = new PrintWriter(socket.getOutputStream(), true);
+
+                boolean isHost = Boolean.parseBoolean(br.readLine());
+
+                if (isHost) {
+                    String hostName = br.readLine();
+                    System.out.println("호스트 : " + hostName + "가 투표 기능에...?");
+                    continue;
+                }
+
+                /*
+                    VoteServer에서 스트림을 연 후에 호스트 여부를 확인하고, VoteHandler의 인자로 socket을 전달한 후,
+                    Vote Handler에서 socket으로부터 스트림을 열어 사용자의 이름을 읽어오려고 했습니다.
+                    근데 VoteHandler 내부에서 socket을 다시 열게 되니 스트림 안에 써준 내용들이 날라가서
+                    이름이 계속 null 값을 읽어오더라구요. 그래서 인자로 br, pw 를 직접 넘겨줬습니다.
+
+                    VoteHandler(socket, onVoteClients) -> X
+
+                    VoteHandler(br, pw, onVoteClients) -> O
+                */
+                VoteHandler voteHandler = new VoteHandler(br, pw, onVoteClients);
                 voteHandler.start();
+
             }
-        } catch (IOException e) {
+        } catch (
+                IOException e) {
             throw new RuntimeException(e);
         }
     }


### PR DESCRIPTION
ScheduleServer, VoteServer 는 클라이언트가 연결 요청을 수행했을 때, 해당 클라이언트가 호스트냐 호스트가 아니냐 여부에 따라 서로 다른 핸들러를 호출해주어야합니다. 그에 따라 호스트 여부를 확인할 수 있는 로직을 추가했습니다. 
이 때 처음에는 기존 네프 예제처럼 스레드에 인자로 소켓을 넘겨서 VoteHandler(socket,...) 이런 식으로 코드를 짜보려고 했습니다. 
이 형태는 VoteServer나 ScheduleServer에서 클라이언트의 호스트 여부를 확인하기 위해 스트림을 한 번 열어 정보를 확인하고, VoteHandler를 수행해서 내부적으로 스트림을 또 다시 열어 사용자의 이름을 확인하게됩니다.

저는 스트림을 2번 열던 말던 하나의 소켓에서 스트림을 획득하게되면 해당 스트림에는 데이터가 유지되고있을 것이라고 생각했는데 그게 아닌 것 같습니다. 소켓에서 스트림을 다시 열게되면 이전 스트림에 남아있던 데이터는 날아가나봐요. 그래서 VoteServer, ScheduleServer에서 미리 스트림을 열어버리고 VoteHandler, ScheduleHandler의 인자로 해당 스트림들을 넘겨주는 방식을 활용했습니다. 

좀 두서없이 말을 했는데 이해가 잘 안되신다면 설명해드리겠습니다.