### PR TITLE
장소 제안 및 장소 투표 기능 구현

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -9,7 +9,7 @@
       </MTProjectMetadataState>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="21" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_23" default="true" project-jdk-name="21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/src/client/ClientCore.java
+++ b/src/client/ClientCore.java
@@ -1,13 +1,12 @@
 package client;
 
+import dto.ClientState;
 import dto.Packet;
 import entity.User;
 
 import java.io.*;
 import java.net.Socket;
 import java.util.Scanner;
-
-import static dto.ClientState.*;
 
 public class ClientCore extends Thread {
     private Socket socket;
@@ -29,9 +28,13 @@ public class ClientCore extends Thread {
 
     @Override
     public void run() {
-        writer.println("Connected to server\n");
+        writer.println("Connected to server");
 
         createClient();
+
+        writer.println(client+ " connected");
+
+        ClientState state = ClientState.HOME;
 
         while (true) {
             showMenuScreen();
@@ -77,8 +80,7 @@ public class ClientCore extends Thread {
     }
 
     private void createClient() {
-        writer.print("이름 : ");
-        writer.flush();
+        writer.println("Enter name");
 
         String userName;
         try {

--- a/src/client/ClientCore.java
+++ b/src/client/ClientCore.java
@@ -20,6 +20,7 @@ public class ClientCore extends Thread {
         try {
             socket = new Socket("localhost", 10000);
             serverOutput = new ObjectOutputStream(socket.getOutputStream());
+            serverOutput.flush();
             serverInput = new ObjectInputStream(socket.getInputStream());
         } catch (IOException e) {
             e.printStackTrace();

--- a/src/client/handler/ClientFeatureHandler.java
+++ b/src/client/handler/ClientFeatureHandler.java
@@ -1,19 +1,21 @@
 package client.handler;
 
+import dto.Packet;
+
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.PrintWriter;
+import java.util.Scanner;
 
 public abstract class ClientFeatureHandler {
-    private final ObjectInputStream serverInput;
-    private final ObjectOutputStream serverOutput;
+    protected final Scanner scanner = new Scanner(System.in);
+    protected final PrintWriter writer = new PrintWriter(System.out, true);
+    protected final ObjectInputStream serverInput;
+    protected final ObjectOutputStream serverOutput;
 
     public ClientFeatureHandler(ObjectInputStream serverInput, ObjectOutputStream serverOutput) {
         this.serverInput = serverInput;
         this.serverOutput = serverOutput;
-    }
-
-    public ObjectInputStream getServerInput() {
-        return serverInput;
     }
 
     public abstract void run();

--- a/src/client/handler/ClientPlaceSuggestHandler.java
+++ b/src/client/handler/ClientPlaceSuggestHandler.java
@@ -1,15 +1,58 @@
 package client.handler;
 
+import dto.ClientState;
+import dto.Packet;
+
+import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
-public class ClientPlaceSuggestHandler extends ClientFeatureHandler{
-    @Override
-    public void run() {
-
-    }
-
+public class ClientPlaceSuggestHandler extends ClientFeatureHandler {
     public ClientPlaceSuggestHandler(ObjectInputStream serverInput, ObjectOutputStream serverOutput) {
         super(serverInput, serverOutput);
+    }
+
+    @Override
+    public void run() {
+        writer.println("Enter the place you want to add.");
+        writer.println("[exit] to go to home");
+
+        String input = scanner.nextLine();
+        String response = null;
+
+        if(input.equals("exit")) {
+            return;
+        }
+
+        response = addPlace(input);
+
+        writer.println(response);
+    }
+
+    private String addPlace(String place) {
+        Packet<String> packet = createPacket(place);
+        String response = null;
+
+        try {
+            sendRequest(packet);
+            response = getResponse();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return response;
+    }
+
+    private Packet<String> createPacket(String place) {
+        return new Packet<String>(ClientState.PLACE_SUGGESTION, place);
+    }
+
+    private void sendRequest(Packet<String> packet) throws IOException {
+        serverOutput.writeObject(packet);
+        serverOutput.flush();
+    }
+
+    private String getResponse() throws IOException, ClassNotFoundException {
+        Packet<String> response = (Packet<String>)serverInput.readObject();
+        return response.body();
     }
 }

--- a/src/client/handler/ClientPlaceSuggestHandler.java
+++ b/src/client/handler/ClientPlaceSuggestHandler.java
@@ -32,11 +32,11 @@ public class ClientPlaceSuggestHandler extends ClientFeatureHandler {
         String input = scanner.nextLine();
         String response = null;
 
-        if(input.equals("exit")) {
+        response = addPlace(input);
+
+        if(response.equals("exit")) {
             return;
         }
-
-        response = addPlace(input);
 
         writer.println(response);
     }

--- a/src/client/handler/ClientPlaceSuggestHandler.java
+++ b/src/client/handler/ClientPlaceSuggestHandler.java
@@ -6,6 +6,7 @@ import dto.Packet;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.util.HashSet;
 
 public class ClientPlaceSuggestHandler extends ClientFeatureHandler {
     public ClientPlaceSuggestHandler(ObjectInputStream serverInput, ObjectOutputStream serverOutput) {
@@ -14,6 +15,17 @@ public class ClientPlaceSuggestHandler extends ClientFeatureHandler {
 
     @Override
     public void run() {
+        HashSet<String> places = null;
+        try {
+            Packet<HashSet<String>> packet = (Packet<HashSet<String>>) serverInput.readObject();
+            places = packet.body();
+            for (String place : places) {
+                writer.println(place);
+            }
+        } catch(Exception e) {
+            e.printStackTrace();
+        }
+
         writer.println("Enter the place you want to add.");
         writer.println("[exit] to go to home");
 

--- a/src/client/handler/ClientVoteHandler.java
+++ b/src/client/handler/ClientVoteHandler.java
@@ -1,15 +1,84 @@
 package client.handler;
 
+import dto.ClientState;
+import dto.HostVoteAction;
+import dto.Packet;
+import entity.User;
+
+import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.util.HashSet;
 
-public class ClientVoteHandler extends ClientFeatureHandler{
-    public ClientVoteHandler(ObjectInputStream serverInput, ObjectOutputStream serverOutput) {
+public class ClientVoteHandler extends ClientFeatureHandler {
+    private User user;
+    public ClientVoteHandler(ObjectInputStream serverInput, ObjectOutputStream serverOutput, User user) {
         super(serverInput, serverOutput);
+        this.user = user;
     }
 
     @Override
     public void run() {
+        try {
+            if(user.isHost()) {
+                handleHost();
+            } else {
+                vote();
+            }
+        } catch (Exception e) {}
+    }
 
+    private void handleHost() throws IOException, ClassNotFoundException {
+        writer.println("Select the menu you want to enter");
+        writer.println("[1]. Start election");
+        writer.println("[2]. End election");
+        writer.println("[3]. Vote");
+        writer.println("type [exit] to exit");
+
+        String input = scanner.nextLine();
+        switch (input) {
+            case "exit":
+                return;
+            case "1":
+                serverOutput.writeObject(new Packet<HostVoteAction>(ClientState.PLACE_VOTE, HostVoteAction.START));
+                break;
+            case "2":
+                serverOutput.writeObject(new Packet<HostVoteAction>(ClientState.PLACE_VOTE, HostVoteAction.END));
+                break;
+            case "3":
+                serverOutput.writeObject(new Packet<HostVoteAction>(ClientState.PLACE_VOTE, HostVoteAction.VOTE));
+                vote();
+            case null, default:
+                break;
+        }
+    }
+
+    private void vote()  throws IOException, ClassNotFoundException {
+        // 1. 투표가 진행중인지 확인
+        Boolean isVoting = false;
+        Packet<Boolean> packet = (Packet<Boolean>) serverInput.readObject();
+        isVoting = packet.body();
+
+        if(!isVoting) {
+            writer.println("Vote is currently unavailable");
+            return;
+        }
+
+        // 2. 장소 목록 공유
+        HashSet<String> places = (HashSet<String>) serverInput.readObject();
+
+        writer.println("Vote the place you want to go");
+
+        for(String place : places){
+            writer.println(place);
+        }
+
+        // 3. 투표 결과 전송
+        String input = scanner.nextLine();
+        serverOutput.writeObject(input);
+
+        // 4. 투표 결과 처리
+        Packet<String> response = (Packet<String>)serverInput.readObject();
+        writer.println(response.body());
     }
 }

--- a/src/client/handler/ClientVoteHandler.java
+++ b/src/client/handler/ClientVoteHandler.java
@@ -41,9 +41,11 @@ public class ClientVoteHandler extends ClientFeatureHandler {
                 return;
             case "1":
                 serverOutput.writeObject(new Packet<HostElectionAction>(ClientState.PLACE_VOTE, HostElectionAction.START));
+                writer.println("Started election");
                 break;
             case "2":
                 serverOutput.writeObject(new Packet<HostElectionAction>(ClientState.PLACE_VOTE, HostElectionAction.END));
+                writer.println("Finished election");
                 break;
             case "3":
                 serverOutput.writeObject(new Packet<HostElectionAction>(ClientState.PLACE_VOTE, HostElectionAction.VOTE));
@@ -59,15 +61,20 @@ public class ClientVoteHandler extends ClientFeatureHandler {
             writer.println("Vote had not started");
             return;
         }
+        // 2. 이미 투표했는지 확인
+        if(hasAlreadyVoted()) {
+            writer.println("You can't vote again");
+            return;
+        }
 
-        // 2. 장소 목록 출력
+        // 3. 장소 목록 출력
         showPlaces();
 
-        // 3. 투표 결과 전송
+        // 4. 투표 결과 전송
         String input = scanner.nextLine();
         serverOutput.writeObject(input);
 
-        // 4. 투표 결과 처리
+        // 5. 투표 결과 처리
         Packet<String> response = (Packet<String>)serverInput.readObject();
         writer.println(response.body());
     }
@@ -90,5 +97,14 @@ public class ClientVoteHandler extends ClientFeatureHandler {
         for(String place : places){
             writer.println(place);
         }
+    }
+
+    private boolean hasAlreadyVoted() throws IOException, ClassNotFoundException {
+        Boolean hasAlreadyVoted = false;
+
+        Packet<Boolean> packet = (Packet<Boolean>) serverInput.readObject();
+        hasAlreadyVoted = packet.body();
+
+        return hasAlreadyVoted;
     }
 }

--- a/src/client/handler/ClientVoteHandler.java
+++ b/src/client/handler/ClientVoteHandler.java
@@ -1,7 +1,7 @@
 package client.handler;
 
 import dto.ClientState;
-import dto.HostVoteAction;
+import dto.HostElectionAction;
 import dto.Packet;
 import entity.User;
 
@@ -40,13 +40,13 @@ public class ClientVoteHandler extends ClientFeatureHandler {
             case "exit":
                 return;
             case "1":
-                serverOutput.writeObject(new Packet<HostVoteAction>(ClientState.PLACE_VOTE, HostVoteAction.START));
+                serverOutput.writeObject(new Packet<HostElectionAction>(ClientState.PLACE_VOTE, HostElectionAction.START));
                 break;
             case "2":
-                serverOutput.writeObject(new Packet<HostVoteAction>(ClientState.PLACE_VOTE, HostVoteAction.END));
+                serverOutput.writeObject(new Packet<HostElectionAction>(ClientState.PLACE_VOTE, HostElectionAction.END));
                 break;
             case "3":
-                serverOutput.writeObject(new Packet<HostVoteAction>(ClientState.PLACE_VOTE, HostVoteAction.VOTE));
+                serverOutput.writeObject(new Packet<HostElectionAction>(ClientState.PLACE_VOTE, HostElectionAction.VOTE));
                 vote();
             case null, default:
                 break;
@@ -55,23 +55,13 @@ public class ClientVoteHandler extends ClientFeatureHandler {
 
     private void vote()  throws IOException, ClassNotFoundException {
         // 1. 투표가 진행중인지 확인
-        Boolean isVoting = false;
-        Packet<Boolean> packet = (Packet<Boolean>) serverInput.readObject();
-        isVoting = packet.body();
-
-        if(!isVoting) {
-            writer.println("Vote is currently unavailable");
+        if(!isVoting()) {
+            writer.println("Vote had not started");
             return;
         }
 
-        // 2. 장소 목록 공유
-        HashSet<String> places = (HashSet<String>) serverInput.readObject();
-
-        writer.println("Vote the place you want to go");
-
-        for(String place : places){
-            writer.println(place);
-        }
+        // 2. 장소 목록 출력
+        showPlaces();
 
         // 3. 투표 결과 전송
         String input = scanner.nextLine();
@@ -80,5 +70,25 @@ public class ClientVoteHandler extends ClientFeatureHandler {
         // 4. 투표 결과 처리
         Packet<String> response = (Packet<String>)serverInput.readObject();
         writer.println(response.body());
+    }
+
+    private boolean isVoting() throws IOException, ClassNotFoundException {
+        Boolean isVoting = false;
+
+        Packet<Boolean> packet = (Packet<Boolean>) serverInput.readObject();
+        isVoting = packet.body();
+
+        return isVoting;
+    }
+
+    private void showPlaces() throws IOException, ClassNotFoundException {
+        Packet<HashSet<String>> packet = (Packet<HashSet<String>>)serverInput.readObject();
+        HashSet<String> places = packet.body();
+
+        writer.println("Vote the place you want to go");
+
+        for(String place : places){
+            writer.println(place);
+        }
     }
 }

--- a/src/dto/ClientState.java
+++ b/src/dto/ClientState.java
@@ -1,10 +1,20 @@
 package dto;
 
 public enum ClientState {
-    CHATTING,
-    PLACE_SUGGESTION,
-    SCHEDULE,
-    STATISTIC,
-    PLACE_VOTE,
-    HOME;
+    CHATTING("chatting"),
+    PLACE_SUGGESTION("place suggestion"),
+    SCHEDULE("schedule"),
+    STATISTIC("statistic"),
+    PLACE_VOTE("place vote"),
+    HOME("home");
+
+    ClientState(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    private final String name;
 }

--- a/src/dto/HostElectionAction.java
+++ b/src/dto/HostElectionAction.java
@@ -1,6 +1,6 @@
 package dto;
 
-public enum HostVoteAction {
+public enum HostElectionAction {
     START,
     END,
     VOTE

--- a/src/dto/HostVoteAction.java
+++ b/src/dto/HostVoteAction.java
@@ -1,0 +1,7 @@
+package dto;
+
+public enum HostVoteAction {
+    START,
+    END,
+    VOTE
+}

--- a/src/entity/User.java
+++ b/src/entity/User.java
@@ -6,12 +6,12 @@ public class User implements Serializable {
     private String userName;
     private boolean isHost;
 
-    public User(String userName) {
-        this.userName = userName;
-        this.isHost = false;
+    public User(boolean isHost) {
+        this.isHost = isHost;
     }
-    public void setHost(boolean host) {
-        isHost = host;
+
+    public void setUserName(String userName) {
+        this.userName = userName;
     }
 
     @Override

--- a/src/entity/User.java
+++ b/src/entity/User.java
@@ -10,11 +10,6 @@ public class User implements Serializable {
         this.userName = userName;
         this.isHost = false;
     }
-
-    public boolean getHost() {
-        return isHost;
-    }
-
     public void setHost(boolean host) {
         isHost = host;
     }
@@ -25,5 +20,13 @@ public class User implements Serializable {
                 "userName='" + userName + '\'' +
                 ", isHost=" + isHost +
                 '}';
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public boolean isHost() {
+        return isHost;
     }
 }

--- a/src/server/ServerCore.java
+++ b/src/server/ServerCore.java
@@ -6,13 +6,14 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class ServerCore extends Thread {
-    private static final Map<String, ObjectOutputStream> onScheduleClients = new HashMap<>();
-    private static final Map<String, ObjectOutputStream> onStatisticClients = new HashMap<>();
-    private static final Map<String, ObjectOutputStream> onVoteClients = new HashMap<>();
-    private static final Map<String, ObjectOutputStream> onPlaceSuggestClients = new HashMap<>();
-    private static final Map<String, ObjectOutputStream> onChatClients = new HashMap<>();
+    private static final ConcurrentHashMap<String, ObjectOutputStream> onScheduleClients = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<String, ObjectOutputStream> onStatisticClients = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<String, ObjectOutputStream> onVoteClients = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<String, ObjectOutputStream> onPlaceSuggestClients = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<String, ObjectOutputStream> onChatClients = new ConcurrentHashMap<>();
     private static ServerSocket serverSocket = null;
     private final PrintWriter writer = new PrintWriter(System.out, true);
 

--- a/src/server/ServerCore.java
+++ b/src/server/ServerCore.java
@@ -40,7 +40,7 @@ public class ServerCore extends Thread {
 
             assert socket != null;
 
-            ServerThread chatServerThread = new ServerThread(
+            ServerThread serverThread = new ServerThread(
                     socket,
                     onChatClients,
                     onScheduleClients,
@@ -48,9 +48,7 @@ public class ServerCore extends Thread {
                     onVoteClients,
                     onPlaceSuggestClients
             );
-            chatServerThread.start();
-
-            writer.println("Add client");
+            serverThread.start();
         }
     }
 }

--- a/src/server/ServerThread.java
+++ b/src/server/ServerThread.java
@@ -104,10 +104,18 @@ public class ServerThread extends Thread {
                     writer.println("statistic");
                 }
                 case PLACE_VOTE -> {
-                    writer.println("vote");
+                    onVoteClients.put(user.getUserName(), clientOutput);
+                    if(user.isHost()) {
+                        new HostVoteHandler(clientInput, clientOutput, onVoteClients, user).run();
+                    } else {
+                        new ServerVoteHandler(clientInput, clientOutput, onVoteClients, user).run();
+                    }
+                    onVoteClients.remove(user.getUserName());
                 }
                 case PLACE_SUGGESTION -> {
-                    writer.println("place-suggest");
+                    onPlaceSuggestClients.put(user.getUserName(), clientOutput);
+                    new ServerPlaceSuggestHandler(clientInput, clientOutput, onPlaceSuggestClients).run();
+                    onPlaceSuggestClients.remove(user.getUserName());
                 }
                 case null, default -> {
                     writer.println("nothing");

--- a/src/server/ServerThread.java
+++ b/src/server/ServerThread.java
@@ -49,31 +49,15 @@ public class ServerThread extends Thread {
             throw new RuntimeException(e);
         }
 
-
-        try {
-            String userName = (String) clientInput.readObject();
-
-            user = new User(userName);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException(e);
-        }
-
-        if (ClientOrderGenerator.getClientOrder() == 1) {
-            user.setHost(true);
-        }
-
-        try {
-            clientOutput.writeObject(user);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        user = new User(ClientOrderGenerator.getClientOrder() == 1);
     }
 
-    // 채팅 기능을 관리하는 스레드
     @Override
     public void run() {
+        setUserName();
+
+        notifyUserInfoToClient();
+
         Integer EMPTY_BODY = 0;
 
         System.out.println(user.getUserName() + " joined");
@@ -121,6 +105,26 @@ public class ServerThread extends Thread {
                     writer.println("nothing");
                 }
             }
+        }
+    }
+
+    private void notifyUserInfoToClient() {
+        try {
+            clientOutput.writeObject(user);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void setUserName() {
+        try {
+            String userName = (String) clientInput.readObject();
+
+            user.setUserName(userName);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
         }
     }
 }

--- a/src/server/ServerThread.java
+++ b/src/server/ServerThread.java
@@ -3,6 +3,7 @@ package server;
 import dto.ClientState;
 import dto.Packet;
 import entity.User;
+import server.handler.normal.ServerPlaceSuggestHandler;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -45,6 +46,7 @@ public class ServerThread extends Thread {
 
         try {
             this.clientOutput = new ObjectOutputStream(socket.getOutputStream());
+            clientOutput.flush();
             this.clientInput = new ObjectInputStream(socket.getInputStream());
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/src/server/ServerThread.java
+++ b/src/server/ServerThread.java
@@ -1,8 +1,8 @@
 package server;
 
-import dto.ClientState;
 import dto.Packet;
 import entity.User;
+import server.handler.host.HostVoteHandler;
 import server.handler.normal.ServerPlaceSuggestHandler;
 import server.handler.normal.ServerVoteHandler;
 
@@ -11,11 +11,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.PrintWriter;
 import java.net.Socket;
-import java.util.HashMap;
 import java.util.Map;
-
-import static dto.ClientState.*;
-import static java.lang.Boolean.*;
 
 public class ServerThread extends Thread {
     private static Map<String, ObjectOutputStream> onChatClients;
@@ -78,17 +74,22 @@ public class ServerThread extends Thread {
     // 채팅 기능을 관리하는 스레드
     @Override
     public void run() {
-        Packet<Object> packet = null;
+        Integer EMPTY_BODY = 0;
+
+        System.out.println(user.getUserName() + " joined");
+        Packet<Integer> packet = null;
 
         while (!currentThread().isInterrupted()) {
             try {
-                packet = (Packet<Object>) clientInput.readObject();
+                packet = (Packet<Integer>) clientInput.readObject();
             } catch (Exception e) {
                 e.printStackTrace();
             }
 
             // TODO : 각각의 기능 구현 필요
             assert packet != null;
+            assert packet.body().equals(EMPTY_BODY);
+
             switch (packet.clientState()) {
                 case HOME -> {
                     writer.println("home");

--- a/src/server/ServerThread.java
+++ b/src/server/ServerThread.java
@@ -4,6 +4,7 @@ import dto.ClientState;
 import dto.Packet;
 import entity.User;
 import server.handler.normal.ServerPlaceSuggestHandler;
+import server.handler.normal.ServerVoteHandler;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -28,7 +29,7 @@ public class ServerThread extends Thread {
 
     private final PrintWriter writer = new PrintWriter(System.out, true);
 
-    private final User client;
+    private final User user;
 
     public ServerThread(
             Socket socket,
@@ -56,7 +57,7 @@ public class ServerThread extends Thread {
         try {
             String userName = (String) clientInput.readObject();
 
-            client = new User(userName);
+            user = new User(userName);
         } catch (IOException e) {
             throw new RuntimeException(e);
         } catch (ClassNotFoundException e) {
@@ -64,11 +65,11 @@ public class ServerThread extends Thread {
         }
 
         if (ClientOrderGenerator.getClientOrder() == 1) {
-            client.setHost(true);
+            user.setHost(true);
         }
 
         try {
-            clientOutput.writeObject(client);
+            clientOutput.writeObject(user);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/server/ServerThread.java
+++ b/src/server/ServerThread.java
@@ -11,14 +11,14 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.PrintWriter;
 import java.net.Socket;
-import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class ServerThread extends Thread {
-    private static Map<String, ObjectOutputStream> onChatClients;
-    private static Map<String, ObjectOutputStream> onScheduleClients;
-    private static Map<String, ObjectOutputStream> onStatisticClients;
-    private static Map<String, ObjectOutputStream> onVoteClients;
-    private static Map<String, ObjectOutputStream> onPlaceSuggestClients;
+    private static ConcurrentHashMap<String, ObjectOutputStream> onChatClients;
+    private static ConcurrentHashMap<String, ObjectOutputStream> onScheduleClients;
+    private static ConcurrentHashMap<String, ObjectOutputStream> onStatisticClients;
+    private static ConcurrentHashMap<String, ObjectOutputStream> onVoteClients;
+    private static ConcurrentHashMap<String, ObjectOutputStream> onPlaceSuggestClients;
 
     private final ObjectInputStream clientInput;
     private final ObjectOutputStream clientOutput;
@@ -29,11 +29,11 @@ public class ServerThread extends Thread {
 
     public ServerThread(
             Socket socket,
-            Map<String, ObjectOutputStream> onChatClients,
-            Map<String, ObjectOutputStream> onScheduleClients,
-            Map<String, ObjectOutputStream> onStatisticClients,
-            Map<String, ObjectOutputStream> onVoteClients,
-            Map<String, ObjectOutputStream> onPlaceSuggestClients
+            ConcurrentHashMap<String, ObjectOutputStream> onChatClients,
+            ConcurrentHashMap<String, ObjectOutputStream> onScheduleClients,
+            ConcurrentHashMap<String, ObjectOutputStream> onStatisticClients,
+            ConcurrentHashMap<String, ObjectOutputStream> onVoteClients,
+            ConcurrentHashMap<String, ObjectOutputStream> onPlaceSuggestClients
     ) {
         ServerThread.onChatClients = onChatClients;
         ServerThread.onScheduleClients = onScheduleClients;

--- a/src/server/handler/host/HostScheduleHandler.java
+++ b/src/server/handler/host/HostScheduleHandler.java
@@ -12,4 +12,9 @@ public class HostScheduleHandler extends ServerScheduleHandler {
     public HostScheduleHandler(ObjectInputStream clientInput, ObjectOutputStream clientOutput, Map<String, ObjectOutputStream> onFeatureClients) {
         super(clientInput, clientOutput, onFeatureClients);
     }
+
+    @Override
+    public void run() {
+        super.run();
+    }
 }

--- a/src/server/handler/host/HostVoteHandler.java
+++ b/src/server/handler/host/HostVoteHandler.java
@@ -12,4 +12,9 @@ public class HostVoteHandler extends ServerVoteHandler {
     public HostVoteHandler(ObjectInputStream clientInput, ObjectOutputStream clientOutput, Map<String, ObjectOutputStream> onFeatureClients) {
         super(clientInput, clientOutput, onFeatureClients);
     }
+
+    @Override
+    public void run() {
+        super.run();
+    }
 }

--- a/src/server/handler/host/HostVoteHandler.java
+++ b/src/server/handler/host/HostVoteHandler.java
@@ -1,7 +1,7 @@
 package server.handler.host;
 
 import dto.ClientState;
-import dto.HostVoteAction;
+import dto.HostElectionAction;
 import dto.Packet;
 import entity.User;
 import server.handler.normal.ServerVoteHandler;
@@ -16,10 +16,10 @@ public class HostVoteHandler extends ServerVoteHandler {
 
     @Override
     public void run() {
-        HostVoteAction action = null;
+        HostElectionAction action = null;
 
         try {
-            Packet<HostVoteAction> packet = (Packet<HostVoteAction>) clientInput.readObject();
+            Packet<HostElectionAction> packet = (Packet<HostElectionAction>) clientInput.readObject();
 
             assert packet.clientState().equals(ClientState.PLACE_VOTE);
             action = packet.body();

--- a/src/server/handler/host/HostVoteHandler.java
+++ b/src/server/handler/host/HostVoteHandler.java
@@ -41,6 +41,7 @@ public class HostVoteHandler extends ServerVoteHandler {
     }
 
     private void startElection() {
+        votes.clear();
         isVoting = true;
     }
 

--- a/src/server/handler/host/HostVoteHandler.java
+++ b/src/server/handler/host/HostVoteHandler.java
@@ -1,20 +1,54 @@
 package server.handler.host;
 
+import dto.ClientState;
+import dto.HostVoteAction;
+import dto.Packet;
+import entity.User;
 import server.handler.normal.ServerVoteHandler;
 
-import java.io.BufferedReader;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.io.PrintWriter;
+import java.io.*;
 import java.util.Map;
 
 public class HostVoteHandler extends ServerVoteHandler {
-    public HostVoteHandler(ObjectInputStream clientInput, ObjectOutputStream clientOutput, Map<String, ObjectOutputStream> onFeatureClients) {
-        super(clientInput, clientOutput, onFeatureClients);
+    public HostVoteHandler(ObjectInputStream clientInput, ObjectOutputStream clientOutput, Map<String, ObjectOutputStream> onFeatureClients, User user) {
+        super(clientInput, clientOutput, onFeatureClients, user);
     }
 
     @Override
     public void run() {
+        HostVoteAction action = null;
+
+        try {
+            Packet<HostVoteAction> packet = (Packet<HostVoteAction>) clientInput.readObject();
+
+            assert packet.clientState().equals(ClientState.PLACE_VOTE);
+            action = packet.body();
+        } catch (Exception e) {}
+
+        switch (action) {
+            case START:
+                startElection();
+                break;
+            case END:
+                endElection();
+                break;
+            case VOTE:
+                votePlace();
+                break;
+            case null, default:
+                break;
+        }
+    }
+
+    private void startElection() {
+        isVoting = true;
+    }
+
+    private void endElection() {
+        isVoting = false;
+    }
+
+    private void votePlace() {
         super.run();
     }
 }

--- a/src/server/handler/normal/ServerChatHandler.java
+++ b/src/server/handler/normal/ServerChatHandler.java
@@ -13,7 +13,7 @@ public class ServerChatHandler extends ServerFeatureHandler {
     }
 
     public void broadcast(String message) {
-        Map<String, ObjectOutputStream> onChatClients = this.getOnFeatureClients();
+        Map<String, ObjectOutputStream> onChatClients = onFeatureClients;
 
         synchronized (onChatClients) {
             Collection<ObjectOutputStream> collection = onChatClients.values();
@@ -28,7 +28,7 @@ public class ServerChatHandler extends ServerFeatureHandler {
     }
 
     @Override
-    void run() {
+    public void run() {
 
     }
 }

--- a/src/server/handler/normal/ServerFeatureHandler.java
+++ b/src/server/handler/normal/ServerFeatureHandler.java
@@ -19,5 +19,11 @@ public abstract class ServerFeatureHandler {
         this.onFeatureClients = onFeatureClients;
     }
 
+    public ServerFeatureHandler(ObjectOutputStream clientOutput, ObjectInputStream clientInput) {
+        this.clientOutput = clientOutput;
+        this.clientInput = clientInput;
+        this.onFeatureClients = null;
+    }
+
     abstract public void run();
 }

--- a/src/server/handler/normal/ServerFeatureHandler.java
+++ b/src/server/handler/normal/ServerFeatureHandler.java
@@ -5,9 +5,9 @@ import java.io.ObjectOutputStream;
 import java.util.Map;
 
 public abstract class ServerFeatureHandler {
-    private final ObjectInputStream clientInput;
-    private final ObjectOutputStream clientOutput;
-    private final Map<String, ObjectOutputStream> onFeatureClients;
+    protected final ObjectInputStream clientInput;
+    protected final ObjectOutputStream clientOutput;
+    protected final Map<String, ObjectOutputStream> onFeatureClients;
 
     public ServerFeatureHandler(
             ObjectInputStream clientInput,
@@ -19,17 +19,5 @@ public abstract class ServerFeatureHandler {
         this.onFeatureClients = onFeatureClients;
     }
 
-    public ObjectInputStream getClientInput() {
-        return clientInput;
-    }
-
-    public ObjectOutputStream getClientOutput() {
-        return clientOutput;
-    }
-
-    public Map<String, ObjectOutputStream> getOnFeatureClients() {
-        return onFeatureClients;
-    }
-
-    abstract void run();
+    abstract public void run();
 }

--- a/src/server/handler/normal/ServerPlaceSuggestHandler.java
+++ b/src/server/handler/normal/ServerPlaceSuggestHandler.java
@@ -31,7 +31,9 @@ public class ServerPlaceSuggestHandler extends ServerFeatureHandler {
             e.printStackTrace();
         }
 
-        if(doesPlaceExist(place)) {
+        if(place.equals("exit")) {
+            packet = createPacket("exit");
+        } else if(doesPlaceExist(place)) {
             packet = createPacket("place already exist");
         } else {
             if(addPlace(place)) {

--- a/src/server/handler/normal/ServerPlaceSuggestHandler.java
+++ b/src/server/handler/normal/ServerPlaceSuggestHandler.java
@@ -68,7 +68,7 @@ public class ServerPlaceSuggestHandler extends ServerFeatureHandler {
         clientOutput.flush();
     }
 
-    public HashSet<String> getPlaces() {
+    public static HashSet<String> getPlaces() {
         return places;
     }
 }

--- a/src/server/handler/normal/ServerPlaceSuggestHandler.java
+++ b/src/server/handler/normal/ServerPlaceSuggestHandler.java
@@ -3,7 +3,9 @@ package server.handler.normal;
 import dto.ClientState;
 import dto.Packet;
 
-import java.io.*;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.HashSet;
 import java.util.Map;
 
@@ -56,7 +58,9 @@ public class ServerPlaceSuggestHandler extends ServerFeatureHandler {
     }
 
     private boolean doesPlaceExist(String place) {
-        return places.contains(place);
+        synchronized (places) {
+            return places.contains(place);
+        }
     }
 
     private Packet<String> createPacket(String place) {

--- a/src/server/handler/normal/ServerPlaceSuggestHandler.java
+++ b/src/server/handler/normal/ServerPlaceSuggestHandler.java
@@ -16,14 +16,14 @@ public class ServerPlaceSuggestHandler extends ServerFeatureHandler {
         super(clientInput, clientOutput, onFeatureClients);
     }
 
-    public ServerPlaceSuggestHandler(ObjectOutputStream clientOutput, ObjectInputStream clientInput) {
-        super(clientOutput, clientInput);
-    }
-
     @Override
     public void run() {
         String place = null;
         Packet<String> packet = null;
+
+        try {
+            clientOutput.writeObject(new Packet<>(ClientState.PLACE_SUGGESTION, new HashSet(places)));
+        } catch (Exception e) {}
 
         try {
             place = getRequest();
@@ -73,6 +73,6 @@ public class ServerPlaceSuggestHandler extends ServerFeatureHandler {
     }
 
     public static HashSet<String> getPlaces() {
-        return places;
+        return new HashSet<>(places);
     }
 }

--- a/src/server/handler/normal/ServerPlaceSuggestHandler.java
+++ b/src/server/handler/normal/ServerPlaceSuggestHandler.java
@@ -1,15 +1,74 @@
 package server.handler.normal;
 
+import dto.ClientState;
+import dto.Packet;
+
 import java.io.*;
+import java.util.HashSet;
 import java.util.Map;
 
 public class ServerPlaceSuggestHandler extends ServerFeatureHandler {
+    private static final HashSet<String> places = new HashSet<>();
+
     public ServerPlaceSuggestHandler(ObjectInputStream clientInput, ObjectOutputStream clientOutput, Map<String, ObjectOutputStream> onFeatureClients) {
         super(clientInput, clientOutput, onFeatureClients);
     }
 
-    @Override
-    void run() {
+    public ServerPlaceSuggestHandler(ObjectOutputStream clientOutput, ObjectInputStream clientInput) {
+        super(clientOutput, clientInput);
+    }
 
+    @Override
+    public void run() {
+        String place = null;
+        Packet<String> packet = null;
+
+        try {
+            place = getRequest();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        if(doesPlaceExist(place)) {
+            packet = createPacket("place already exist");
+        } else {
+            if(addPlace(place)) {
+                packet = createPacket("Added " + place);
+            }
+        }
+
+        try {
+            sendResponse(packet);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private boolean addPlace(String place) {
+        synchronized (places) {
+            return places.add(place);
+        }
+    }
+
+    private String getRequest() throws IOException, ClassNotFoundException {
+        Packet<String> request = (Packet<String>) clientInput.readObject();
+        return request.body();
+    }
+
+    private boolean doesPlaceExist(String place) {
+        return places.contains(place);
+    }
+
+    private Packet<String> createPacket(String place) {
+        return new Packet<>(ClientState.PLACE_SUGGESTION, place);
+    }
+
+    private void sendResponse(Packet<String> packet) throws IOException {
+        clientOutput.writeObject(packet);
+        clientOutput.flush();
+    }
+
+    public HashSet<String> getPlaces() {
+        return places;
     }
 }

--- a/src/server/handler/normal/ServerScheduleHandler.java
+++ b/src/server/handler/normal/ServerScheduleHandler.java
@@ -9,7 +9,7 @@ public class ServerScheduleHandler extends ServerFeatureHandler {
     }
 
     @Override
-    void run() {
+    public void run() {
 
     }
 }

--- a/src/server/handler/normal/ServerStatisticHandler.java
+++ b/src/server/handler/normal/ServerStatisticHandler.java
@@ -9,7 +9,7 @@ public class ServerStatisticHandler extends ServerFeatureHandler {
     }
 
     @Override
-    void run() {
+    public void run() {
 
     }
 }

--- a/src/server/handler/normal/ServerVoteHandler.java
+++ b/src/server/handler/normal/ServerVoteHandler.java
@@ -1,15 +1,60 @@
 package server.handler.normal;
 
+import dto.ClientState;
+import dto.Packet;
+import entity.User;
+
 import java.io.*;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 
 public class ServerVoteHandler extends ServerFeatureHandler {
-    @Override
-    public void run() {
+    protected final User user;
+    protected static final HashMap<User, String> votes = new HashMap<>();
+    protected static Boolean isVoting = false;
+    private HashSet<String> places = null;
 
+    public ServerVoteHandler(ObjectInputStream clientInput, ObjectOutputStream clientOutput, Map<String, ObjectOutputStream> onFeatureClients, User user) {
+        super(clientInput, clientOutput, onFeatureClients);
+        this.user = user;
+        this.places = new ServerPlaceSuggestHandler(clientOutput, clientInput).getPlaces();
     }
 
-    public ServerVoteHandler(ObjectInputStream clientInput, ObjectOutputStream clientOutput, Map<String, ObjectOutputStream> onFeatureClients) {
-        super(clientInput, clientOutput, onFeatureClients);
+    @Override
+    public void run() {
+        try {
+            vote();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void vote() throws IOException, ClassNotFoundException {
+        // 1. 투표가 진행중인지 확인
+        clientOutput.writeObject(new Packet<Boolean>(ClientState.PLACE_VOTE, isVoting));
+
+        if(!isVoting) {
+            return;
+        }
+
+        // 2. 장소 목록 공유
+        clientOutput.writeObject(places);
+
+        // 3. 투표 결과 전송
+        String place = (String) clientInput.readObject();
+
+        if(votes.containsKey(user)) {
+            clientOutput.writeObject(new Packet<String>(ClientState.PLACE_VOTE, "You can't vote again"));
+            return;
+        }
+        if(!places.contains(place)) {
+            clientOutput.writeObject(new Packet<String>(ClientState.PLACE_VOTE, "You voted to the place that doesn't exist"));
+            return;
+        }
+        votes.put(user, place);
+
+        // 4. 투표 결과 처리
+        clientOutput.writeObject(new Packet<String>(ClientState.PLACE_VOTE, "You've voted to " + place));
     }
 }

--- a/src/server/handler/normal/ServerVoteHandler.java
+++ b/src/server/handler/normal/ServerVoteHandler.java
@@ -49,9 +49,12 @@ public class ServerVoteHandler extends ServerFeatureHandler {
             clientOutput.writeObject(new Packet<String>(ClientState.PLACE_VOTE, "You can't vote again"));
             return;
         }
-        if(!places.contains(place)) {
-            clientOutput.writeObject(new Packet<String>(ClientState.PLACE_VOTE, "You voted to the place that doesn't exist"));
-            return;
+
+        synchronized (places) {
+            if(!places.contains(place)) {
+                clientOutput.writeObject(new Packet<String>(ClientState.PLACE_VOTE, "You voted to the place that doesn't exist"));
+                return;
+            }
         }
         votes.put(user, place);
 

--- a/src/server/handler/normal/ServerVoteHandler.java
+++ b/src/server/handler/normal/ServerVoteHandler.java
@@ -4,14 +4,16 @@ import dto.ClientState;
 import dto.Packet;
 import entity.User;
 
-import java.io.*;
-import java.util.HashMap;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class ServerVoteHandler extends ServerFeatureHandler {
     protected final User user;
-    protected static final HashMap<User, String> votes = new HashMap<>();
+    protected static final ConcurrentHashMap<User, String> votes = new ConcurrentHashMap<>();
     protected static Boolean isVoting = false;
     private final HashSet<String> places = ServerPlaceSuggestHandler.getPlaces();;
 

--- a/src/server/handler/normal/ServerVoteHandler.java
+++ b/src/server/handler/normal/ServerVoteHandler.java
@@ -13,12 +13,11 @@ public class ServerVoteHandler extends ServerFeatureHandler {
     protected final User user;
     protected static final HashMap<User, String> votes = new HashMap<>();
     protected static Boolean isVoting = false;
-    private HashSet<String> places = null;
+    private final HashSet<String> places = ServerPlaceSuggestHandler.getPlaces();;
 
     public ServerVoteHandler(ObjectInputStream clientInput, ObjectOutputStream clientOutput, Map<String, ObjectOutputStream> onFeatureClients, User user) {
         super(clientInput, clientOutput, onFeatureClients);
         this.user = user;
-        this.places = new ServerPlaceSuggestHandler(clientOutput, clientInput).getPlaces();
     }
 
     @Override

--- a/src/server/handler/normal/ServerVoteHandler.java
+++ b/src/server/handler/normal/ServerVoteHandler.java
@@ -39,17 +39,15 @@ public class ServerVoteHandler extends ServerFeatureHandler {
             return;
         }
 
-        // 2. 장소 목록 공유
+        // 2. 이미 투표했는지 확인
+        sendResponse(votes.containsKey(user));
+
+        // 3. 장소 목록 공유
         sendResponse(places);
         System.out.println("Send " + places + " to " + user.getUserName());
 
-        // 3. 투표 결과 전송
+        // 4. 투표 결과 전송
         String place = (String) clientInput.readObject();
-
-        if(votes.containsKey(user)) {
-            sendResponse("You can't vote again");
-            return;
-        }
 
         synchronized (places) {
             if(!places.contains(place)) {
@@ -59,7 +57,7 @@ public class ServerVoteHandler extends ServerFeatureHandler {
         }
         votes.put(user, place);
 
-        // 4. 투표 결과 처리
+        // 5. 투표 결과 처리
         sendResponse("You've voted to " + place);
     }
 

--- a/src/server/handler/normal/ServerVoteHandler.java
+++ b/src/server/handler/normal/ServerVoteHandler.java
@@ -33,32 +33,37 @@ public class ServerVoteHandler extends ServerFeatureHandler {
 
     private void vote() throws IOException, ClassNotFoundException {
         // 1. 투표가 진행중인지 확인
-        clientOutput.writeObject(new Packet<Boolean>(ClientState.PLACE_VOTE, isVoting));
+        sendResponse(isVoting);
 
         if(!isVoting) {
             return;
         }
 
         // 2. 장소 목록 공유
-        clientOutput.writeObject(places);
+        sendResponse(places);
+        System.out.println("Send " + places + " to " + user.getUserName());
 
         // 3. 투표 결과 전송
         String place = (String) clientInput.readObject();
 
         if(votes.containsKey(user)) {
-            clientOutput.writeObject(new Packet<String>(ClientState.PLACE_VOTE, "You can't vote again"));
+            sendResponse("You can't vote again");
             return;
         }
 
         synchronized (places) {
             if(!places.contains(place)) {
-                clientOutput.writeObject(new Packet<String>(ClientState.PLACE_VOTE, "You voted to the place that doesn't exist"));
+                sendResponse("You voted to the place that doesn't exist");
                 return;
             }
         }
         votes.put(user, place);
 
         // 4. 투표 결과 처리
-        clientOutput.writeObject(new Packet<String>(ClientState.PLACE_VOTE, "You've voted to " + place));
+        sendResponse("You've voted to " + place);
+    }
+
+    private void sendResponse(Object body) throws IOException {
+        clientOutput.writeObject(new Packet<>(ClientState.PLACE_VOTE, body));
     }
 }

--- a/src/server/handler/normal/ServerVoteHandler.java
+++ b/src/server/handler/normal/ServerVoteHandler.java
@@ -5,7 +5,7 @@ import java.util.Map;
 
 public class ServerVoteHandler extends ServerFeatureHandler {
     @Override
-    void run() {
+    public void run() {
 
     }
 


### PR DESCRIPTION
# What's new?
- 모임에서 만나기를 희망하는 장소를 등록할 수 있습니다.
- 모임을 어떤 장소에서 진행할지 투표할 수 있습니다.

# Description
두 기능 모두 일회성으로 사용하도록 구현했습니다. 특정 기능을 사용하면 이후에 다시 클라이언트에서 메인 페이지로 돌아갑니다.
## 장소 제안
희망하는 장소를 제안하고, 해당 장소를 추후 투표에 사용할 수 있도록 저장합니다.

기존에 존재하던 장소 목록은 장소를 추가하기 전에 보여주고, 추가된 장소를 알려줍니다. 

## 장소 투표
장소 제안을 통해 생성된 장소 목록 중 한 곳을 투표할 수 있습니다.
- #9를 참고해 투표는 한 사람 당 한 번만 진행할 수 있도록 구현했습니다.
- 현재 투표가 종료된 후 다시 투표를 시작하면 투표 내역을 초기화하는 기능이 없는데 투표를 여러번 진행 가능하도록 구현할지 논의해봐야 할 것 같습니다. 

# Discussion
막상 구현하고 보니 패킷에 대한 필요성도 의문이 생기고, 프레임워크를 사용하지 못해 DI를 사용할 수 없어 코드를 짜는데 불편함이 많은 것 같습니다. 다른 분들 개발하면서 드신 생각이 궁금합니다.

따로 request/response dispatcher가 존재하지 않다보니 각 핸들러마다 요청과 응답을 처리해 줘야 하는데 공통 클래스를 만드는 게 나을 수도 있을 것 같다는 생각을 합니다. 매번 패킷을 생성할 때나, 프로토콜을 정의할 때 더 유용할 수 있을 것 같아요. 그렇지 않으면 클라이언트 사이드 핸들러와 서버 사이드 핸들러의 프로토콜 싱크를 코드를 보며 맞춰야 하는데 이게 디버깅할 때 상당히 힘듭니다. 

# Related to
Resolves #11: 상균님이 제안해주신 대로 `static HashSet`을 그대로 반환하는 것이 아닌 각 상황마다 새로운 객체를 반환하는 방법으로 로직을 변경했습니다. 
